### PR TITLE
Uniformize role variable names

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,7 +16,7 @@ haproxy_sysctl_entries:
 
 # Rsyslog configuration
 haproxy_rsyslog_managed: true
-rsyslog_service_name: rsyslog
+haproxy_rsyslog_service_name: rsyslog
 haproxy_rsyslog_conf_template: rsyslog_haproxy.conf.j2
 haproxy_rsyslog_conf_path: /etc/rsyslog.d/49-haproxy.conf
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -8,6 +8,6 @@
 
 - name: restart rsyslog
   service:
-    name: "{{ rsyslog_service_name }}"
+    name: "{{ haproxy_rsyslog_service_name }}"
     state: restarted
 


### PR DESCRIPTION
Or was this to "inherit" the variable from outside of the role ? In which case it could be handled more properly as: `{% if rsyslog_service_name is defined %}{{ rsyslog_service_name }}{% else %}rsyslog{% endif %}`