### PR TITLE
add provision mode only mode to prevent service from reload/restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ An Ansible role for configure HAproxy for openio SDS. Specifically, the responsi
 | `haproxy_sysctl_managed` | `true` | [LEGACY] sysctl file creation  |
 | `haproxy_sysctl_template_dest` | `/etc/sysctl.d/49-haproxy.conf` | [LEGACY] sysctl file |
 | `haproxy_virtual_address` | `172.17.0.100` | Virtual IP address |
+| `haproxy_provision_only` | `false` | Provision only without restarting or reloading services |
 
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,9 @@ haproxy_logrotate_conf_template: logrotate_haproxy.conf.j2
 haproxy_logrotate_template_conf_path: /etc/logrotate.d/haproxy
 haproxy_logrotate_retention: 5
 
+# provision only to prevent restart/reload of the service
+haproxy_provision_only: false
+
 
 ##### HAproxy configuration file
 # Global

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,6 +5,7 @@
   service:
     name: "{{ haproxy_service_name }}"
     state: reloaded
+  when: not haproxy_provision_only
 
 - name: restart rsyslog
   service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -84,4 +84,5 @@
     name: "{{ haproxy_service_name }}"
     state: started
     enabled: true
+  when: not haproxy_provision_only
 ...


### PR DESCRIPTION
Should we also prevent rsyslog from restarting/reloading when haproxy rsyslog configuration is modified ?