### PR TITLE
FEATURE(haproxy): Ensure service is started

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -89,4 +89,9 @@
     state: started
     enabled: true
   when: not haproxy_provision_only
+
+- name: 'HAproxy: Check service status'
+  command: "systemctl status {{ haproxy_service_name }}"
+  changed_when: false
+  when: not haproxy_provision_only
 ...


### PR DESCRIPTION
 ##### SUMMARY
Check HAProxy service status at the end of the role to ensure it
is actually started. Even if the Ansible service module is called
with a "started" state, service could be down (due to binding
problem for example) and role ends without errors. The role ensure
now you end up with a started service.

 ##### IMPACT
N/A