### PR TITLE
CHANGE(haproxy): Increase server timeout to prevent 504 errors

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -86,7 +86,7 @@ haproxy_defaults_errorfiles:
 haproxy_defaults_timeouts:
   - connect 5s
   - client  60s
-  - server  60s
+  - server  600s
   - http-request 15s
   - queue 1m
   - http-keep-alive 10s


### PR DESCRIPTION
 ##### SUMMARY

Previously, haproxy would timeout a request after 60s causing 504 errors
However, long requests in S3 could take longer. This increases the
timeout for these requests

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION