### PR TITLE
Revert "CHANGE(haproxy): Increase server timeout to prevent 504 errors"

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -86,7 +86,7 @@ haproxy_defaults_errorfiles:
 haproxy_defaults_timeouts:
   - connect 5s
   - client  60s
-  - server  600s
+  - server  60s
   - http-request 15s
   - queue 1m
   - http-keep-alive 10s


### PR DESCRIPTION
Reverts open-io/ansible-role-openio-haproxy#25
What makes you think waiting for 60 seconds for a response is normal ? We need more informations here.