### PR TITLE
BUGFIX/MEDIUM(haproxy): Fix keystone backend healthcheck

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -208,11 +208,19 @@ haproxy_backend_instances:
     mode: http
     balance: roundrobin
     server: "{{ haproxy_keystone_admin_backend_url | list_backends(name='keystone-admin', check='5s') }}"
+    option: 'httpchk POST /v3/auth/tokens HTTP/1.1\r\nContent-Type:\ application/json\r\nContent-Length:\ 140\
+\r\n\r\n{\"auth\":{\"identity\":{\"methods\":[\"password\"],\"password\":{\"user\":{\"name\":\"h34lthch3ck\",\
+\"domain\":{\"id\":\"default\"},\"password\":\"h34lthch3ck\"}}}}}'
+    http-check: "expect status 401"
   # KEYSTONE PUBLIC
   - name: keystone-public-backend
     mode: http
     balance: roundrobin
     server: "{{ haproxy_keystone_public_backend_url | list_backends(name='keystone-public', check='5s') }}"
+    option: 'httpchk POST /v3/auth/tokens HTTP/1.1\r\nContent-Type:\ application/json\r\nContent-Length:\ 140\
+\r\n\r\n{\"auth\":{\"identity\":{\"methods\":[\"password\"],\"password\":{\"user\":{\"name\":\"h34lthch3ck\",\
+\"domain\":{\"id\":\"default\"},\"password\":\"h34lthch3ck\"}}}}}'
+    http-check: "expect status 401"
   # CONSCIENCE
   - name: conscience-backend
     mode: tcp


### PR DESCRIPTION
 ##### SUMMARY

Previously, the healthcheck performed on keystone instances was
insufficient. Keystone returns a successful 200 HTTP code to any request
made to "/", even when his backend (mysql/galera) isn't available. This
results in requests being routed to broken keystone requests, thus a
partial service outage as soon as any Keystone instance is broken.

This improves the healthcheck by performing an actual request (with
bogus data). Any broken Keystone would respond in a 5xx response code
(usually 500), while an operational one would simply respond with 401
Unauthorized.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION