### PR TITLE
FEATURE(haproxy): Define the number of core allocated

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,6 +36,8 @@ haproxy_global_log_socket: 127.0.0.1
 haproxy_global_log_facility: local5
 haproxy_global_log_level: info
 
+haproxy_global_nbproc: 1
+
 haproxy_global_chroot: /var/lib/haproxy
 
 haproxy_global_user: haproxy

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -3,6 +3,8 @@ global
   log {{ haproxy_global_log_socket }}:514 {{ haproxy_global_log_facility }} {{ haproxy_global_log_level }}
   chroot {{ haproxy_global_chroot }}
 
+  nbproc {{ haproxy_global_nbproc }}
+
   user {{ haproxy_global_user }}
   group {{ haproxy_global_group }}
   daemon


### PR DESCRIPTION
 ##### SUMMARY

Meanwhile, the way to use `nbthread` (appeared in version 1.8), it is already useful to be able to configure the number of core used by the daemon.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
OB-455

By default, only one process is created, which is the recommended mode
of operation