### PR TITLE
BUGFIX/MEDIUM(haproxy): Don't use multiline for http packet

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -208,18 +208,17 @@ haproxy_backend_instances:
     mode: http
     balance: roundrobin
     server: "{{ haproxy_keystone_admin_backend_url | list_backends(name='keystone-admin', check='5s') }}"
-    option: 'httpchk POST /v3/auth/tokens HTTP/1.1\r\nContent-Type:\ application/json\r\nContent-Length:\ 140\
-\r\n\r\n{\"auth\":{\"identity\":{\"methods\":[\"password\"],\"password\":{\"user\":{\"name\":\"h34lthch3ck\",\
-\"domain\":{\"id\":\"default\"},\"password\":\"h34lthch3ck\"}}}}}'
+    # This needs to be passed as is (rawx HTTP packet), so we cant use multiline easily without breaking it.
+    # yamllint disable-line rule:line-length
+    option: 'httpchk POST /v3/auth/tokens HTTP/1.1\r\nContent-Type:\ application/json\r\nContent-Length:\ 140\r\n\r\n{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"h34lthch3ck","domain":{"id":"default"},"password":"h34lthch3ck"}}}}}'
     http-check: "expect status 401"
   # KEYSTONE PUBLIC
   - name: keystone-public-backend
     mode: http
     balance: roundrobin
     server: "{{ haproxy_keystone_public_backend_url | list_backends(name='keystone-public', check='5s') }}"
-    option: 'httpchk POST /v3/auth/tokens HTTP/1.1\r\nContent-Type:\ application/json\r\nContent-Length:\ 140\
-\r\n\r\n{\"auth\":{\"identity\":{\"methods\":[\"password\"],\"password\":{\"user\":{\"name\":\"h34lthch3ck\",\
-\"domain\":{\"id\":\"default\"},\"password\":\"h34lthch3ck\"}}}}}'
+    # yamllint disable-line rule:line-length
+    option: 'httpchk POST /v3/auth/tokens HTTP/1.1\r\nContent-Type:\ application/json\r\nContent-Length:\ 140\r\n\r\n{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"h34lthch3ck","domain":{"id":"default"},"password":"h34lthch3ck"}}}}}'
     http-check: "expect status 401"
   # CONSCIENCE
   - name: conscience-backend


### PR DESCRIPTION
 ##### SUMMARY

Trying to split the raw HTTP packet used for checking Keystone breaks
the packet itself; It needs to be passed as is, so we just ignore it

Related to #29

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION