### PR TITLE
BUGFIX/MEDIUM(haproxy): Fix keystone check on newer haproxy versions

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -211,16 +211,14 @@ haproxy_backend_instances:
     balance: roundrobin
     server: "{{ haproxy_keystone_admin_backend_url | list_backends(name='keystone-admin', check='5s') }}"
     # This needs to be passed as is (rawx HTTP packet), so we cant use multiline easily without breaking it.
-    # yamllint disable-line rule:line-length
-    option: 'httpchk POST /v3/auth/tokens HTTP/1.1\r\nContent-Type:\ application/json\r\nContent-Length:\ 140\r\n\r\n{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"h34lthch3ck","domain":{"id":"default"},"password":"h34lthch3ck"}}}}}'
+    option: "{{ haproxy_keystone_check_packet }}"
     http-check: "expect status 401"
   # KEYSTONE PUBLIC
   - name: keystone-public-backend
     mode: http
     balance: roundrobin
     server: "{{ haproxy_keystone_public_backend_url | list_backends(name='keystone-public', check='5s') }}"
-    # yamllint disable-line rule:line-length
-    option: 'httpchk POST /v3/auth/tokens HTTP/1.1\r\nContent-Type:\ application/json\r\nContent-Length:\ 140\r\n\r\n{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"h34lthch3ck","domain":{"id":"default"},"password":"h34lthch3ck"}}}}}'
+    option: "{{ haproxy_keystone_check_packet }}"
     http-check: "expect status 401"
   # CONSCIENCE
   - name: conscience-backend

--- a/vars/1.5.yml
+++ b/vars/1.5.yml
@@ -4,4 +4,6 @@ haproxy_log_format_https: "%ci:%cp\\ [%t]\\ %ft\\ %b/%s\\ w=%Tw/c=%Tc/r=%Tr/t=%T
   /%fc/%bc/%sc\\ /%rc\\ %sq/%bq\\ %hr\\ %hs\\ %{+Q}r\\ %ID"
 haproxy_log_format_http: "%ci:%cp\\ [%t]\\ %ft\\ %b/%s\\ w=%Tw/c=%Tc/t=%Tt\\ %B\\ %ts\\ %ac/%fc/%bc/%sc/%rc\\ %sq/%bq"
 haproxy_log_format_tcp: "%ci:%cp\\ [%t]\\ %ft\\ %b/%s\\ w=%Tw/c=%Tc/t=%Tt\\ %B\\ %ts\\ %ac/%fc/%bc/%sc/%rc\\ %sq/%bq"
+# yamllint disable-line rule:line-length
+haproxy_keystone_check_packet: 'httpchk POST /v3/auth/tokens HTTP/1.1\r\nContent-Type:\ application/json\r\nContent-Length:\ 140\r\n\r\n{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"h34lthch3ck","domain":{"id":"default"},"password":"h34lthch3ck"}}}}}'
 ...

--- a/vars/1.6.yml
+++ b/vars/1.6.yml
@@ -3,4 +3,6 @@ haproxy_log_format_https: "\"%ci:%cp [%t] %ft %b/t=%Tt q=%Tq w=%Tw c=%Tc r=%Tr/%
   %CS %tsc %ac/%fc/%bc/%sc/%rc %sq/%bq %hr %hs %{+Q}r %ID\""
 haproxy_log_format_http: "\"%ci:%cp [%t] %ft %b/t=%Tt q=%Tq w=%Tw c=%Tc r=%Tr/%B %ts %ac/%fc/%bc/%sc/%rc %sq/%bq\""
 haproxy_log_format_tcp: "\"%ci:%cp [%t] %ft %b/t=%Tt w=%Tw c=%Tc/%B %ts %ac/%fc/%bc/%sc/%rc %sq/%bq\""
+# yamllint disable-line rule:line-length
+haproxy_keystone_check_packet: 'httpchk POST "/v3/auth/tokens HTTP/1.1\r\nContent-Type:\ application/json\r\nContent-Length:\ 140\r\n\r\n{\"auth\":{\"identity\":{\"methods\":[\"password\"],\"password\":{\"user\":{\"name\":\"h34lthch3ck\",\"domain\":{\"id\":\"default\"},\"password\":\"h34lthch3ck\"}}}}}"'
 ...

--- a/vars/1.8.yml
+++ b/vars/1.8.yml
@@ -4,4 +4,6 @@ haproxy_log_format_https: "\"%ci:%cp [%t] %ft %b/%s h=%Th/i=%Ti/R=%TR/w=%Tw/c=%T
   %CS %tsc %ac/%fc/%bc/%sc/%rc %sq/%bq %hr %hs %{+Q}r %ID\""
 haproxy_log_format_http: "\"%ci:%cp [%t] %ft %b/%s h=%Th/w=%Tw/c=%Tc/d=%Td/t=%Tt %B %ts %ac/%fc/%bc/%sc/%rc %sq/%bq\""
 haproxy_log_format_tcp: "\"%ci:%cp [%t] %ft %b/t=%Tt w=%Tw c=%Tc/%B %ts %ac/%fc/%bc/%sc/%rc %sq/%bq\""
+# yamllint disable-line rule:line-length
+haproxy_keystone_check_packet: 'httpchk POST "/v3/auth/tokens HTTP/1.1\r\nContent-Type:\ application/json\r\nContent-Length:\ 140\r\n\r\n{\"auth\":{\"identity\":{\"methods\":[\"password\"],\"password\":{\"user\":{\"name\":\"h34lthch3ck\",\"domain\":{\"id\":\"default\"},\"password\":\"h34lthch3ck\"}}}}}"'
 ...


### PR DESCRIPTION
 ##### SUMMARY

HAproxy 1.6-dev1 fixed the stats body parsing, which broke the packet
and thus the keystone healthcheck. This crafts different HTTP packets
depending on the shipped haproxy version.

WARNING: Updating haproxy from 1.5 to 1.6 without reprovisioning will break the healthcheck

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION

Changelog line for the above fix:
    - BUG/MEDIUM: http: fix body processing for the stats applet