### PR TITLE
CHANGE(haproxy): Add flag to force package upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ An Ansible role for configure HAproxy for openio SDS. Specifically, the responsi
 | `haproxy_sysctl_template_dest` | `/etc/sysctl.d/49-haproxy.conf` | [LEGACY] sysctl file |
 | `haproxy_virtual_address` | `172.17.0.100` | Virtual IP address |
 | `haproxy_provision_only` | `false` | Provision only without restarting or reloading services |
+| `haproxy_package_upgrade` | `false` | Set the packages to the latest version (to be set in extra_vars) |
 
 
 
@@ -207,17 +208,17 @@ node1 ansible_host=192.168.1.173
 Creating a .pem with the private key and entire trust chain
 
 ```
------BEGIN RSA PRIVATE KEY----- 
-(Your Private Key: mydomain.org.key) 
------END RSA PRIVATE KEY----- 
------BEGIN CERTIFICATE----- 
-(Your Primary SSL certificate: mydomain.org.crt) 
------END CERTIFICATE----- 
------BEGIN CERTIFICATE----- 
-(Your Intermediate certificate: intermediateCA.crt) 
------END CERTIFICATE----- 
------BEGIN CERTIFICATE----- 
-(Your Root certificate: TrustedRoot.crt) 
+-----BEGIN RSA PRIVATE KEY-----
+(Your Private Key: mydomain.org.key)
+-----END RSA PRIVATE KEY-----
+-----BEGIN CERTIFICATE-----
+(Your Primary SSL certificate: mydomain.org.crt)
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+(Your Intermediate certificate: intermediateCA.crt)
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+(Your Root certificate: TrustedRoot.crt)
 -----END CERTIFICATE-----
 -----BEGIN X9.42 DH PARAMETERS-----
 (Your DH paramaters)
@@ -273,4 +274,3 @@ GNU AFFERO GENERAL PUBLIC LICENSE, Version 3
 - [Cedric DELGEHIER](https://github.com/cdelgehier) (maintainer)
 - [Romain ACCIARI](https://github.com/racciari) (maintainer)
 - [Vincent LEGOLL](https://github.com/vincent-legoll) (maintainer)
-

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,7 @@ haproxy_logrotate_retention: 5
 # provision only to prevent restart/reload of the service
 haproxy_provision_only: false
 
+haproxy_package_upgrade: "{{ openio_package_upgrade | d(false) }}"
 
 ##### HAproxy configuration file
 # Global

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
 - name: 'HAproxy: Install packages'
   package:
     name: "{{ item }}"
-    state: present
+    state: "{{ 'latest' if haproxy_package_upgrade else 'present' }}"
   with_items: "{{ haproxy_packages }}"
   register: install_packages
   until: install_packages is success


### PR DESCRIPTION
 ##### SUMMARY

This is useful during upgrades, as it allows to update packages to the
latest version without requiring an external playbook/task.

To use this, simply provide the -e openio_package_upgrade=true argument

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION

The diff on the certificate is the consequence of an auto-linter, please
disregard.