### PR TITLE
BUGFIX/MINOR(haproxy): Add compat with python3

### DIFF
--- a/filter_plugins/haproxy.py
+++ b/filter_plugins/haproxy.py
@@ -1,3 +1,5 @@
+from six import string_types
+
 class FilterModule(object):
     def filters(self):
         return {
@@ -7,7 +9,7 @@ class FilterModule(object):
     def list_backends(self, list_backends, name, active=0, check="0"):
         backends = list()
 
-        if isinstance(list_backends, basestring):
+        if isinstance(list_backends, string_types):
             list_backends = list_backends.split()
 
         for index, backend in enumerate(list_backends):


### PR DESCRIPTION
 ##### SUMMARY

`basestring` is removed from python3
The `six` library helps to guarantee the both compat.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
```

fatal: [node03]: FAILED! => changed=false
  msg: 'AnsibleError: An unhandled exception occurred while templating ''[{''name'': ''swift-backend'', ''mode'': ''http'', ''balance'': ''roundrobin'', ''server'': "{{ haproxy_swift_backend_url | list_backends(name=''swift-proxy'', check=''5s'') }}"}, {''name'': ''keystone-admin-backend'', ''mode'': ''http'', ''balance'': ''roundrobin'', ''server'': "{{ haproxy_keystone_admin_backend_url | list_backends(name=''keystone-admin'', check=''5s'') }}", ''option'': ''{{ haproxy_keystone_check_packet }}'', ''http-check'': ''expect status 401''}, {''name'': ''keystone-public-backend'', ''mode'': ''http'', ''balance'': ''roundrobin'', ''server'': "{{ haproxy_keystone_public_backend_url | list_backends(name=''keystone-public'', check=''5s'') }}", ''option'': ''{{ haproxy_keystone_check_packet }}'', ''http-check'': ''expect status 401''}, {''name'': ''conscience-backend'', ''mode'': ''tcp'', ''option'': [''tcp-check''], ''server'': "{{ haproxy_conscience_backend_url | list_backends(name=''conscience'',
    active=1, check=''5s'') }}"}]''. Error was a <class ''NameError''>, original message: name ''basestring'' is not defined'
```